### PR TITLE
Fix for issue with builds that have never been run

### DIFF
--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -242,8 +242,10 @@ function updateBuildStatusForBuild(currentBuildModel, callback) {
 		+ "/builds?count=1";
 
 	rest.get(getBuildStatusUrl).on('complete', function(data){
-		var lastBuildOfProject = data.builds.build[0].$;
-		updateModel(currentBuildModel, lastBuildOfProject);
+		if (data.builds.$.count !== '0') {
+			var lastBuildOfProject = data.builds.build[0].$;
+			updateModel(currentBuildModel, lastBuildOfProject);
+		}
 	});
 
 	if(callback)


### PR DESCRIPTION
Was running the app against a TeamCity server that had builds that have never been run. This would throw an error when trying to get the build[0] value as it didn't exist.

Not sure how to write tests for this, bit of a node newb :smile: 
