### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:5
+
+RUN apt-get install git
+ADD . /inspiration-ci
+WORKDIR /inspiration-ci
+RUN npm install -g sails && \
+    npm install
+EXPOSE 1337
+
+CMD ["sails", "lift"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Launch server
 
 Open your browser to http://localhost:1337 and maximize the browser to full screen and see you builds displayed.
 
+Using docker:
+```
+docker build -t inspiration-ci .
+docker run -Pt inspiration-ci
+```
+
+Then run `docker ps` to find-out which port to use and launch your browser to http://localhost:PORT.
+
 
 About:
 


### PR DESCRIPTION
This allows you to run the CI in Docker:

```
docker build -t inspiration-ci .
docker run -Pt inspiration-ci
```

Currently getting an error though.  I've used both node 5 and node 6 - same error for both.

```
 ~/Documents/experiments/inspiration-ci  ⑂ docker +    docker run -Pt inspiration-ci

info: Starting app...

module.js:341
    throw err;
    ^

Error: Cannot find module 'express/node_modules/cookie'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Module.require (module.js:367:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/inspiration-ci/node_modules/sails/lib/hooks/session/index.js:9:12)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:20:19)
    at /inspiration-ci/node_modules/sails/lib/app/configuration/index.js:54:28
    at Function.reduce (/inspiration-ci/node_modules/sails/node_modules/lodash/dist/lodash.js:3735:25)
    at Configuration.defaultConfig (/inspiration-ci/node_modules/sails/lib/app/configuration/index.js:53:18)
    at Configuration.bound [as defaults] (/inspiration-ci/node_modules/sails/node_modules/lodash/dist/lodash.js:729:21)
    at Array.async.auto.mixinDefaults (/inspiration-ci/node_modules/sails/lib/app/configuration/load.js:136:41)
```
